### PR TITLE
Default to `cache-read-only` for non-default branches

### DIFF
--- a/.github/workflows/integ-test-action-inputs-caching.yml
+++ b/.github/workflows/integ-test-action-inputs-caching.yml
@@ -31,6 +31,7 @@ jobs:
     - name: Setup Gradle
       uses: ./
       with:
+        cache-read-only: false # For testing, allow writing cache entries on non-default branches
         # Add "enterprise" to main cache entry but omit "notifications"
         gradle-home-cache-includes: |
             caches

--- a/.github/workflows/integ-test-execution-with-caching.yml
+++ b/.github/workflows/integ-test-execution-with-caching.yml
@@ -31,6 +31,7 @@ jobs:
     - name: Execute Gradle build
       uses: ./
       with:
+        cache-read-only: false # For testing, allow writing cache entries on non-default branches
         build-root-directory: .github/workflow-samples/groovy-dsl
         arguments: test
 

--- a/.github/workflows/integ-test-execution.yml
+++ b/.github/workflows/integ-test-execution.yml
@@ -36,6 +36,7 @@ jobs:
     - name: Test use defined Gradle version
       uses: ./
       with:
+        cache-read-only: false # For testing, allow writing cache entries on non-default branches
         gradle-version: 6.9
         build-root-directory: .github/workflow-samples/no-wrapper
         arguments: help -DgradleVersionCheck=6.9
@@ -72,6 +73,7 @@ jobs:
       uses: ./
       id: gradle
       with:
+        cache-read-only: false # For testing, allow writing cache entries on non-default branches
         gradle-version: ${{matrix.gradle}}
         build-root-directory: .github/workflow-samples/no-wrapper${{ matrix.build-root-suffix }}
         arguments: help -DgradleVersionCheck=${{matrix.gradle}}

--- a/.github/workflows/integ-test-provision-gradle-versions.yml
+++ b/.github/workflows/integ-test-provision-gradle-versions.yml
@@ -36,6 +36,7 @@ jobs:
     - name: Setup Gradle with v6.9
       uses: ./
       with:
+        cache-read-only: false # For testing, allow writing cache entries on non-default branches
         gradle-version: 6.9
     - name: Test uses Gradle v6.9
       working-directory: .github/workflow-samples/no-wrapper
@@ -74,6 +75,7 @@ jobs:
     - name: Setup Gradle
       uses: ./
       with:
+        cache-read-only: false # For testing, allow writing cache entries on non-default branches
         gradle-version: ${{ matrix.gradle }}
     - name: Run Gradle build
       id: gradle

--- a/.github/workflows/integ-test-restore-configuration-cache.yml
+++ b/.github/workflows/integ-test-restore-configuration-cache.yml
@@ -32,6 +32,8 @@ jobs:
       uses: ./.github/actions/download-dist
     - name: Setup Gradle
       uses: ./
+      with:
+        cache-read-only: false # For testing, allow writing cache entries on non-default branches
     - name: Groovy build with configuration-cache enabled
       working-directory: .github/workflow-samples/groovy-dsl
       run: ./gradlew test --configuration-cache
@@ -102,6 +104,8 @@ jobs:
       uses: ./.github/actions/download-dist
     - name: Setup Gradle
       uses: ./
+      with:
+        cache-read-only: false # For testing, allow writing cache entries on non-default branches
     - name: Execute 'help' with configuration-cache enabled
       working-directory: .github/workflow-samples/kotlin-dsl
       run: ./gradlew help --configuration-cache
@@ -121,6 +125,8 @@ jobs:
       uses: ./.github/actions/download-dist
     - name: Setup Gradle
       uses: ./
+      with:
+        cache-read-only: false # For testing, allow writing cache entries on non-default branches
     - name: Execute 'test' with configuration-cache enabled
       working-directory: .github/workflow-samples/kotlin-dsl
       run: ./gradlew test --configuration-cache

--- a/.github/workflows/integ-test-restore-custom-gradle-home.yml
+++ b/.github/workflows/integ-test-restore-custom-gradle-home.yml
@@ -30,6 +30,8 @@ jobs:
       uses: ./.github/actions/download-dist
     - name: Setup Gradle
       uses: ./
+      with:
+        cache-read-only: false # For testing, allow writing cache entries on non-default branches
     - name: Build using Gradle wrapper
       working-directory: .github/workflow-samples/groovy-dsl
       run: ./gradlew test --info

--- a/.github/workflows/integ-test-restore-gradle-home.yml
+++ b/.github/workflows/integ-test-restore-gradle-home.yml
@@ -31,6 +31,8 @@ jobs:
       uses: ./.github/actions/download-dist
     - name: Setup Gradle
       uses: ./
+      with:
+        cache-read-only: false # For testing, allow writing cache entries on non-default branches
     - name: Build using Gradle wrapper
       working-directory: .github/workflow-samples/groovy-dsl
       run: ./gradlew test

--- a/.github/workflows/integ-test-restore-java-toolchain.yml
+++ b/.github/workflows/integ-test-restore-java-toolchain.yml
@@ -30,6 +30,8 @@ jobs:
       uses: ./.github/actions/download-dist
     - name: Setup Gradle
       uses: ./
+      with:
+        cache-read-only: false # For testing, allow writing cache entries on non-default branches
     - name: Build using Gradle wrapper
       working-directory: .github/workflow-samples/java-toolchain
       run: ./gradlew test --info

--- a/.github/workflows/integ-test-sample-gradle-plugin.yml
+++ b/.github/workflows/integ-test-sample-gradle-plugin.yml
@@ -30,6 +30,8 @@ jobs:
       uses: ./.github/actions/download-dist
     - name: Setup Gradle
       uses: ./
+      with:
+        cache-read-only: false # For testing, allow writing cache entries on non-default branches
     - name: Build gradle-plugin project
       working-directory: .github/workflow-samples/gradle-plugin
       run: ./gradlew build

--- a/.github/workflows/integ-test-sample-kotlin-dsl.yml
+++ b/.github/workflows/integ-test-sample-kotlin-dsl.yml
@@ -30,6 +30,8 @@ jobs:
       uses: ./.github/actions/download-dist
     - name: Setup Gradle
       uses: ./
+      with:
+        cache-read-only: false # For testing, allow writing cache entries on non-default branches
     - name: Build kotlin-dsl project
       working-directory: .github/workflow-samples/kotlin-dsl
       run: ./gradlew build

--- a/action.yml
+++ b/action.yml
@@ -14,11 +14,13 @@ inputs:
     default: false
 
   cache-read-only:
-    description: When 'true', existing entries will be read from the cache but no entries will be written.
+    description: |
+      When 'true', existing entries will be read from the cache but no entries will be written.
+      By default this value is 'false' for workflows on the GitHub default branch and 'true' for workflows on other branches.
     required: false
-    default: false 
+    default: ${{ github.ref_name != github.event.repository.default_branch }}
   # e.g. Use the following setting to only write cache entries from your 'main' branch
-  #     cache-read-only: ${{ github.ref != 'refs/heads/main' }}
+  #     cache-read-only: ${{ github.ref_name != 'main' }}
 
   gradle-home-cache-includes:
     description: Paths within Gradle User Home to cache.

--- a/action.yml
+++ b/action.yml
@@ -22,6 +22,13 @@ inputs:
   # e.g. Use the following setting to only write cache entries from your 'main' branch
   #     cache-read-only: ${{ github.ref_name != 'main' }}
 
+  cache-write-only:
+    description: |
+      When 'true', entries will not be restored from the cache but will be saved at the end of the Job. 
+      Setting this to 'true' implies cache-read-only will be 'false'.
+    required: false
+    default: false
+
   gradle-home-cache-includes:
     description: Paths within Gradle User Home to cache.
     required: false
@@ -52,10 +59,6 @@ inputs:
   # The following action properties allow fine-grained tweaking of the action caching behaviour.
   # These properties are experimental and not (yet) designed for production use, and may change without notice in a subsequent release of `gradle-build-action`.
   # Use at your own risk!
-  cache-write-only:
-    description: When 'true', entries will not be restored from the cache but will be saved at the end of the Job. This allows a 'clean' cache entry to be written.
-    required: false
-    default: false
   gradle-home-cache-strict-match:
     description: When 'true', the action will not attempt to restore the Gradle User Home entries from other Jobs.
     required: false

--- a/src/cache-utils.ts
+++ b/src/cache-utils.ts
@@ -27,7 +27,7 @@ export function isCacheDisabled(): boolean {
 }
 
 export function isCacheReadOnly(): boolean {
-    return core.getBooleanInput(CACHE_READONLY_PARAMETER)
+    return !isCacheWriteOnly() && core.getBooleanInput(CACHE_READONLY_PARAMETER)
 }
 
 export function isCacheWriteOnly(): boolean {


### PR DESCRIPTION
This takes a common optimization pattern and makes it default behaviour.
See #143.