### PR TITLE
Avoid appending to existing build-results file

### DIFF
--- a/src/resources/init-scripts/build-result-capture-service.plugin.groovy
+++ b/src/resources/init-scripts/build-result-capture-service.plugin.groovy
@@ -54,6 +54,8 @@ abstract class BuildResultsRecorder implements BuildService<BuildResultsRecorder
         def buildResultsDir = new File(runnerTempDir, ".build-results")
         buildResultsDir.mkdirs()
         def buildResultsFile = new File(buildResultsDir, githubActionStep + getParameters().getInvocationId().get() + ".json")
-        buildResultsFile << groovy.json.JsonOutput.toJson(buildResults)
+        if (!buildResultsFile.exists()) {
+            buildResultsFile << groovy.json.JsonOutput.toJson(buildResults)
+        }
     }
 }


### PR DESCRIPTION
When configuration-cache is enabled, the invocationId may not be unique, which can result in mulitple builds writing to the same file. Rather than failing the post-action, we simply ignore any subsequent build results with the same ID.

Fixes #441