### PR TITLE
Fix for Gradle 7.6 compatibility

### DIFF
--- a/.github/workflow-samples/gradle-plugin/plugin/build.gradle
+++ b/.github/workflow-samples/gradle-plugin/plugin/build.gradle
@@ -29,7 +29,7 @@ testing {
         functionalTest(JvmTestSuite) {
             dependencies {
                 // functionalTest test suite depends on the production code in tests
-                implementation project
+                implementation(project(':plugin'))
             }
 
             targets {


### PR DESCRIPTION
Uprade to Gradle 7.6 is currently failing because of `Could not find method implementation() for arguments [project ':plugin'] on object of type org.gradle.api.plugins.jvm.internal.DefaultJvmComponentDependencies`

This change fixes it 