### PR TITLE
840: Fix configuration name in dependency filtering section

### DIFF
--- a/README.md
+++ b/README.md
@@ -461,7 +461,7 @@ You can provide this value via the `DEPENDENCY_GRAPH_INCLUDE_PROJECTS` environme
 To restrict which Gradle configurations contribute to the report, you can filter configurations by name using a regular expression.
 You can provide this value via the `DEPENDENCY_GRAPH_INCLUDE_CONFIGURATIONS` environment variable or system property.
 
-Example of a simple workflow that limits the dependency graph to `RuntimeClasspath` configuration:
+Example of a simple workflow that limits the dependency graph to `runtimeClasspath` configuration:
 ```yaml
 name: Submit dependency graph
 on:
@@ -479,8 +479,8 @@ jobs:
       uses: gradle/gradle-build-action@v2
       with:
         dependency-graph: generate-and-submit
-    - name: Run a build, generating the dependency graph from 'RuntimeClasspath' configurations
-      run: ./gradlew build -DDEPENDENCY_GRAPH_INCLUDE_CONFIGURATIONS=RuntimeClasspath
+    - name: Run a build, generating the dependency graph from 'runtimeClasspath' configurations
+      run: ./gradlew build -DDEPENDENCY_GRAPH_INCLUDE_CONFIGURATIONS=runtimeClasspath
 ```
 
 ### Gradle version compatibility


### PR DESCRIPTION
Fixes: https://github.com/gradle/gradle-build-action/issues/840

With Gradle 8.0.2 (not tried other versions) the configuration name is runtimeClasspath not RuntimeClasspath. Using the latter results in an empty set of dependencies being reported (as it matches no configurations).