### PR TITLE
Add example of using  `DEPENDENCY_GRAPH_INCLUDE_PROJECTS` to docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -461,7 +461,7 @@ You can provide this value via the `DEPENDENCY_GRAPH_INCLUDE_PROJECTS` environme
 To restrict which Gradle configurations contribute to the report, you can filter configurations by name using a regular expression.
 You can provide this value via the `DEPENDENCY_GRAPH_INCLUDE_CONFIGURATIONS` environment variable or system property.
 
-Example of a simple workflow that limits the dependency graph to `RuntimeClasspath` configuration:
+Example of a simple workflow that limits the dependency graph to `RuntimeClasspath` configuration and to exclude `buildSrc` dependencies:
 ```yaml
 name: Submit dependency graph
 on:
@@ -481,6 +481,8 @@ jobs:
         dependency-graph: generate-and-submit
     - name: Run a build, generating the dependency graph from 'RuntimeClasspath' configurations
       run: ./gradlew build -DDEPENDENCY_GRAPH_INCLUDE_CONFIGURATIONS=RuntimeClasspath
+      env:
+        DEPENDENCY_GRAPH_INCLUDE_PROJECTS: "^:(?!buildSrc).*"
 ```
 
 ### Gradle version compatibility


### PR DESCRIPTION
Users will currently need to spend some time working out the required regex when using `DEPENDENCY_GRAPH_INCLUDE_PROJECTS`. Providing an example will get users up to speed quicker.