### PR TITLE
docs: upload build reports even when build failed

### DIFF
--- a/README.md
+++ b/README.md
@@ -417,6 +417,7 @@ jobs:
       run: ./gradlew build --scan
     - name: Upload build reports
       uses: actions/upload-artifact@v3
+      if: always()
       with:
         name: build-reports
         path: build/reports/


### PR DESCRIPTION
Hello 👋 

Really thanks for making this action very well documented!
It helped me to try new features with less effort 👍 

I found that the doc contains a description regarding the usage of `actions/upload-artifact`, then I suggest adding `if: always()` or `if: failure()`.
Because in most cases I check build reports to understand what made my build unstable.

Thanks for checking this PR!