### PR TITLE
Fix typo in `README.md`

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@
 > uses: gradle/actions/setup-gradle@v3
 > ```
 >
-> See the [setup-gradle documentation](https://github.com/gradle/actions/tree/main/setup-gradle) for up-to-date documentation for `gradle/actons/setup-gradle`. 
+> See the [setup-gradle documentation](https://github.com/gradle/actions/tree/main/setup-gradle) for up-to-date documentation for `gradle/actions/setup-gradle`. 
 
 # Execute Gradle builds in GitHub Actions workflows
 


### PR DESCRIPTION
The same typo also exist in the release notes:
- https://github.com/gradle/gradle-build-action/releases/tag/v3.0.0